### PR TITLE
Fixed a style collision with twitter bootstrap.

### DIFF
--- a/podlove-web-player/podlove-web-player.css
+++ b/podlove-web-player/podlove-web-player.css
@@ -435,6 +435,7 @@ filter: dropshadow(color=#000000, offx=0, offy=0);
 	font-smoothing: antialiased;
 	text-decoration: none;
 	speak: none;
+	display: inline;
 }
 
 .podlovewebplayer_wrapper .podlovewebplayer_controlbox .infobuttons,


### PR DESCRIPTION
The icons inherited 'display: inline-block;' from bootstrap.
