### PR TITLE
Centered play and pause characters

### DIFF
--- a/podlove-web-player/podlove-web-player.css
+++ b/podlove-web-player/podlove-web-player.css
@@ -199,6 +199,7 @@
 	font-family: "pwpfont" !important;
 	font-style: normal;
 	font-weight: normal;
+	line-height: 1.33em;
 	speak: none;
 	color: #ffffff;
 	background: transparent !important;
@@ -220,6 +221,7 @@
 
 .podlovewebplayer_meta .bigplay:before {
 	content: "\25b6";
+	padding-left: 0.02em;
 }
 
 .podlovewebplayer_meta .bigplay:focus,


### PR DESCRIPTION
It kept bugging me. And it's open source, so:

Moved play and pause characters one pixel down in FF and Chrome and also one pixel to the left (in FF only).
