### PR TITLE
Fehler im .gitmodules, wodurch mediaelements nicht ausgecheckt wird.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "podlove-web-player/libs/mediaelement"]
-        path = podlove-web-player/libs/mediaelement/
+        path = podlove-web-player/libs/mediaelement
         url=https://github.com/podlove/mediaelement.git


### PR DESCRIPTION
Umstellung der URL auf https://, weil vorher das Submodul wegen fehlender Berechtigung nicht mit ausgecheckt wurde, was auch den .zip-Download beeinträchtigt hat.

Das Submodul bringt grundsätzlich das Problem mit sich, dass bei git keine einzelnen Subordner (in dem Fall bräuchte man ja nur /build/) ausgecheckt werden können, wodurch ganz schön viele Daten aus dem mediaelements geladen werden müssen.
