### PR TITLE
Added new setting `rememberPlaytime`

### DIFF
--- a/podlove-web-player/podlove-web-player.js
+++ b/podlove-web-player/podlove-web-player.js
@@ -139,8 +139,10 @@
 	 * add a string as hash in the adressbar
 	 * @param string fragment
 	 **/
-	setFragmentURL = function (fragment) {
-		window.location.hash = fragment;
+	setFragmentURL = function (player, fragment) {
+		if(player.params.rememberPlaytime) {
+			window.location.hash = fragment;
+		}
 	};
 
 	/**
@@ -203,7 +205,7 @@
 		var fragment;
 		if (players.length === 1) {
 			fragment = 't=' + generateTimecode([e.data.player.currentTime]);
-			setFragmentURL(fragment);
+			setFragmentURL(e.data.player, fragment);
 		}
 	};
 
@@ -611,8 +613,8 @@
 		
 				// If there is only one player also set deepLink
 				if (players.length === 1) {
-					// setFragmentURL('t=' + generateTimecode([startTime, endTime]));
-					setFragmentURL('t=' + generateTimecode([startTime]));
+					// setFragmentURL(player, 't=' + generateTimecode([startTime, endTime]));
+					setFragmentURL(player, 't=' + generateTimecode([startTime]));
 				} else {
 					if (canplay) {
 						// Basic Chapter Mark function (without deeplinking)
@@ -690,11 +692,13 @@
 			.on('play playing', function () {
 				if (!player.persistingTimer) {
 					player.persistingTimer = window.setInterval(function () {
-						if (players.length === 1) {
+						if (players.length === 1 && player.params.rememberPlaytime) {
 							ignoreHashChange = true;
 							window.location.replace('#t=' + generateTimecode([player.currentTime, false]));
 						}
-						localStorage['podloveWebPlayerTime-' + params.permalink] = player.currentTime;
+						if(player.params.rememberPlaytime) {
+							localStorage['podloveWebPlayerTime-' + params.permalink] = player.currentTime;
+						}
 					}, 5000);
 				}
 				list.find('.paused').removeClass('paused');
@@ -756,6 +760,7 @@
 			hidedownloadbutton: false,
 			hidesharebutton: false,
 			sharewholeepisode: false,
+			rememberPlaytime: true,
 			sources: []
 		}, options);
 
@@ -836,6 +841,7 @@
 
 			player = $(player).clone().wrap('<div class="podlovewebplayer_wrapper" style="width: ' + params.width + '"></div>')[0];
 			wrapper = $(player).parent();
+			player.params = params;
 
 			players.push(player);
 
@@ -1048,7 +1054,7 @@
 				}
 				startAtTime = deepLink[0];
 				stopAtTime = deepLink[1];
-			} else if (params && params.permalink) {
+			} else if (params && params.permalink && params.rememberPlaytime) {
 				storageKey = 'podloveWebPlayerTime-' + params.permalink;
 				if (localStorage[storageKey]) {
 					$(player).one('canplay', function () {

--- a/podlove-web-player/readme.md
+++ b/podlove-web-player/readme.md
@@ -194,6 +194,10 @@ Defines the default visibility status of toggable player modules. Standard value
 
     [podloveaudio chaptersVisible="true" timecontrolsVisible="false" summaryVisible="false"]
 
+### rememberPlaytime
+
+Enables (`true`) or disables (`false`) the deeplinking URL and localStorage to remember the current play time.
+
 ### Rich Podlove Web Player player with meta information
 
 **If you have an audio file and use one of the following attributes, the player will sport a richer visual experience:** "title", "subtitle", "summary", "poster", "permalink". Full example:  

--- a/podlove-web-player/readme.txt
+++ b/podlove-web-player/readme.txt
@@ -200,6 +200,10 @@ Defines the default visibility status of toggable player modules. Standard value
 
     [podloveaudio chaptersVisible="true" timecontrolsVisible="false" summaryVisible="false"]
 
+= rememberPlaytime =
+
+Enables (`true`) or disables (`false`) the deeplinking URL and localStorage to remember the current play time.
+
 = Rich Podlove Web Player player with meta information =
 
 If you have an audio file and use one of the following attributes, the player will sport a richer visual experience: "title", "subtitle", "summary", "poster", "permalink". Full example:

--- a/podlove-web-player/standalone.html
+++ b/podlove-web-player/standalone.html
@@ -39,6 +39,7 @@
 				summaryVisible: false,
 				timecontrolsVisible: false,
 				sharebuttonsVisible: false,
+				rememberPlaytime: true,
 				chaptersVisible: true	
 			});
 		</script>
@@ -71,6 +72,7 @@
 				summaryVisible: false,
 				timecontrolsVisible: false,
 				sharebuttonsVisible: false,
+				rememberPlaytime: true,
 				chaptersVisible: false	
 			});
 		</script>


### PR DESCRIPTION
This adds a new setting called `rememberPlaytime`. It enables developers to disable the hash and localStorage usage to store the current play time. The standard value for this is `true`, so the behavior does not change from the current.

I've added this to the defaults in `podlove-web-player.js`, to `readme.md`, `readme.txt` and `standalone.html`. Please let me know if something is missing.
