### PR TITLE
Improving summary CSS and JS

### DIFF
--- a/podlove-web-player/static/podlove-web-player.css
+++ b/podlove-web-player/static/podlove-web-player.css
@@ -1521,8 +1521,8 @@
 	transition: all 0.5s;
 }
 
-.podlovewebplayer_meta .summary .summarydiv {
-	margin: 0px 5px;
+.podlovewebplayer_meta + .summary .summarydiv {
+	padding: 25px 10px 35px;
 }
 
 .podlovewebplayer_video .podlovewebplayer_meta + .summary,
@@ -1533,7 +1533,6 @@
 .podlovewebplayer_meta + .summary.active {
 	min-height: 35px;
 	height: auto;
-  padding: 25px 10px 35px;
 }
 
 .podlovewebplayer_wrapper .summary a:visited {

--- a/podlove-web-player/static/podlove-web-player.js
+++ b/podlove-web-player/static/podlove-web-player.js
@@ -623,28 +623,28 @@ if (typeof String.prototype.trim !== 'function') {
     marks = list.find('tr');
     // fix height of summary for better toggability
     summary.each(function () {
-      $(this).data('height', $(this).height() + 10);
+      $(this).data('height', $(this).height());
       if (!$(this).hasClass('active')) {
-        $(this).height('0px');
+        $(this).height(0);
       } else {
-        $(this).height($(this).find('div.summarydiv').height() + 10 + 'px');
+        $(this).height($(this).find('div.summarydiv').outerHeight());
       }
     });
     chapterdiv.each(function () {
       $(this).data('height', $(this).find('.podlovewebplayer_chapters').height());
       if (!$(this).hasClass('active')) {
-        $(this).height('0px');
+        $(this).height(0);
       } else {
-        $(this).height($(this).find('.podlovewebplayer_chapters').height() + 'px');
+        $(this).height($(this).find('.podlovewebplayer_chapters').outerHeight());
       }
     });
     if (metainfo.length === 1) {
       metainfo.find('a.infowindow').click(function () {
         summary.toggleClass('active');
         if (summary.hasClass('active')) {
-          summary.height(summary.find('div.summarydiv').height() + 10 + 60 + 'px');
+          summary.height(summary.find('div.summarydiv').outerHeight());
         } else {
-          summary.css('height', '0px');
+          summary.css('height', 0);
         }
         return false;
       });


### PR DESCRIPTION
I removed some hard-coded pixel values from the JS and switched some CSS around to allow for a design-independent code. There might be some other places where this should be done.

---

Moved style from .summary to .summarydiv and added missing '+'

Replaced $.height() with $.outerHeight() in some places and removed hardcoded pixel values
Removed some unnecessary 'px'es in JS
