### PR TITLE
Reorder elements in info tab

### DIFF
--- a/src/js/modules/info.js
+++ b/src/js/modules/info.js
@@ -39,10 +39,10 @@ function createEpisodeInfo(tab, params) {
 
   tab.createSection(
     '<h2>' + params.title + '</h2>' +
-    '<p>Published: ' + date.getDate() + '.' + date.getMonth() + '.' + date.getFullYear() + '</p>' +
     '<em>' + params.subtitle + '</em>' +
     '<p>' + params.summary + '</p>' +
     '<p>Duration: ' + timeCode.fromTimeStamp(params.duration) + '</p>' +
+    '<p>Published: ' + date.getDate() + '.' + date.getMonth() + '.' + date.getFullYear() + '</p>' +
     '<p>' +
       'Permalink for this episode:<br>' +
       '<a href="' + params.permalink + '">' + params.permalink + '</a>' +
@@ -72,9 +72,9 @@ function createSubscribeButton(params) {
 function createShowInfo (tab, params) {
   tab.createAside(
     '<h2>'+ params.show.title+ '</h2>' +
-    createPosterImage(params.poster) +
-    createSubscribeButton(params) +
     '<p>' + params.show.subtitle + '</p>' +
+    createPosterImage(params.show.poster) +
+    createSubscribeButton(params) +
     '<p>Link to the show:<br>' +
       '<a href="' + params.show.url + '">' + params.show.url + '</a></p>'
   );


### PR DESCRIPTION
Fixes ticket https://trello.com/c/FR0oCV9q
- duration and date of publish appear at the end of episode description
- the episode's subtitle is placed under its main title
- the episode image in the sidebar is replaced by the show image
