### PR TITLE
render modules immediately, if possible

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -292,16 +292,6 @@ function addBehavior(player, params, wrapper) {
     player.play();
   });
 
-  // wait for the player or you'll get DOM EXCEPTIONS
-  // And just listen once because of a special behaviour in firefox
-  // --> https://bugzilla.mozilla.org/show_bug.cgi?id=664842
-  jqPlayer.one('canplay', function (evt) {
-    console.debug('canplay', evt);
-    timeline.duration = player.duration;
-    // attach and render modules
-    renderModules(timeline, wrapper, params);
-  });
-
   $(document)
     .on('keydown', function (e) {
       console.log('progress', 'keydown', e);
@@ -382,6 +372,20 @@ function addBehavior(player, params, wrapper) {
       // delete the cached play time
       timeline.rewind();
     });
+
+  var delayModuleRendering = !timeline.duration || isNaN(timeline.duration) || timeline.duration <= 0;
+
+  if (!delayModuleRendering) {
+    renderModules(timeline, wrapper, params);
+  }
+
+  jqPlayer.one('canplay', function () {
+    // correct duration just in case
+    timeline.duration = player.duration;
+    if (delayModuleRendering) {
+      renderModules(timeline, wrapper, params);
+    }
+  });
 }
 
 /**


### PR DESCRIPTION
If `delayModuleRendering` is true, modules are rendered after the
`canplay` event is fired.
This speeds up rendering for configurations where all necessary data is
already given at load.

On a side note https://bugzilla.mozilla.org/show_bug.cgi?id=664842 was
fixed as irrelevant