### PR TITLE
browsersync back in, with sync off by default

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -13,6 +13,7 @@ var gulp = require('gulp')
 // deactivate caching until issue is resolved
 //  , cache = require('gulp-cache')
   , browserify = require('gulp-browserify')
+  , browserSync = require('browser-sync')
   , karma = require('karma').server
   , _ = require('lodash')
   , karmaConf = require('./karma.conf.json')
@@ -143,6 +144,13 @@ gulp.task('default', ['lint', 'test'], function() {
 
 // Watch
 gulp.task('watch', function() {
+  // Browsersync configuration
+  browserSync({
+    server: { // serve dist directory as server
+        baseDir: './dist/'
+    },
+    ghostMode: false  // ghost mode (interaction sync) disabled by default -> enable in ui
+  });
 
   // Watch Sass source files
   gulp.watch(source + 'sass/**/*.scss', ['styles']);

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "player"
   ],
   "devDependencies": {
+    "browser-sync": "^2.10.0",
     "browserify": "^10.2.0",
     "del": "^1.1.1",
     "gulp": "^3.8.11",


### PR DESCRIPTION
Using Browsersync for the server functionality, sync off by default.
Enable syncing if wanted here: http://localhost:3001 (while server is running).