### PR TITLE
Clear-up layout for download elements 

### DIFF
--- a/src/sass/modules/_downloads.scss
+++ b/src/sass/modules/_downloads.scss
@@ -24,22 +24,10 @@
     min-width: 156px;
     height: auto;
   }
-
-  // Container for overlay image
-  .download-overlay {
-    background:url('../img/download-overlay.png') no-repeat;
-    background-position: center;
-    position: absolute;
-    right: 0;
-    bottom: 0;
-    width: 100%;
-    height: 100%;
-    margin: 0 auto;
-  }
 }
 
 .download {
-  margin: 20px auto;
+  margin: 0 auto 20px auto;
   @media screen and (max-width: $screen-phone) {
     margin: 0 auto;
   }
@@ -66,14 +54,19 @@
   &.button-submit {
     display: block;
     margin: 0 auto $margin-base-horizontal auto;
-    padding: 15px;
     font-size: $font-size-large;
+    max-width: 500px;
+    width: 95vw;
+
     @media screen and (max-width: $screen-tiny-phone) {
-      width: 95vw;
+      height: 40px;
     }
-    @media screen and (min-width: $screen-tiny-phone) {
+    @media screen and (min-width: $screen-phone) {
+      padding: 15px;
+      width: auto;
+    }
+    @media screen and (min-width: $screen-tablet) {
       font-size: $font-size-xlarge;
-      padding: 18px;
     }
   }
   // Label of download button
@@ -119,7 +112,7 @@ select::-ms-expand { /* for IE 11 */
   border: 1px solid $select-border;
   margin: 0 auto $margin-base-vertical auto;
   height: 40px;
-  padding: 6px 12px;
+  padding: 6px 38px 6px 12px;
   font-size: $font-size-small;
   line-height: 1.4;
   color: $select-color !important;
@@ -129,19 +122,15 @@ select::-ms-expand { /* for IE 11 */
   -moz-appearance: none;
   appearance: none;
   overflow:hidden;
-  background: url(/img/arrow-down-white.png) 96% no-repeat #ddd;
+  background: url('/img/arrow-down-white.png') 95% no-repeat #ddd;
   text-overflow: ellipsis;
   white-space: nowrap;
+  width: 95vw;
 
-  @media screen and (max-width: $screen-tiny-phone) {
-    width: 95vw;
-  }
-  @media screen and (min-width: $screen-tiny-phone) {
-    width: 50vw;
-    font-size: $font-size-base;
-  }
   @media screen and (min-width: $screen-phone) {
     margin: 0 auto $margin-small-vertical auto;
+    font-size: $font-size-base;
+    width: auto;
   }
   @media screen and (min-width: $screen-desktop) {
     margin: 0 auto $margin-base-horizontal auto;


### PR DESCRIPTION
- Mobile view: Dropdown and Button get 100% width
- Reduce padding and font-size of download button
- Delete unused overlay image
