### PR TITLE
Hide licence area if licence is unclear

### DIFF
--- a/src/js/modules/info.js
+++ b/src/js/modules/info.js
@@ -84,15 +84,27 @@ function createSocialInfo(profiles) {
   return container;
 }
 
+/**
+ * Create footer with license area and social media profiles,
+ * if (params.license && params.show) and params.profiles
+ * are defined
+ * @param  {Tab} tab
+ * @param  {object} params
+ */
 function createSocialAndLicenseInfo (tab, params) {
-  if (!params.license || !params.show) {
+  var footer;
+  if ((!params.license.url || !params.license.name || !params.show.title) && !params.profiles) {
     return;
   }
-  var footer = tab.createFooter(
-    '<p>Die Show "' + params.show.title + '" ist lizensiert unter<br>' +
-      '<a href="' + params.license.url + '" target="_blank" title="Lizenz ansehen">' + params.license.name + '</a>' +
-    '</p>'
-  )
+  if (params.license.url && params.license.name && params.show.title) {
+    footer = tab.createFooter(
+      '<p class="license-area">Die Show "' + params.show.title + '" ist lizensiert unter<br>' +
+        '<a href="' + params.license.url + '" target="_blank" title="Lizenz ansehen">' + params.license.name + '</a>' +
+      '</p>'
+    );
+  } else {
+    footer = tab.createFooter();
+  }
   footer.prepend(createSocialInfo(params.profiles));
 }
 

--- a/src/js/modules/info.js
+++ b/src/js/modules/info.js
@@ -93,7 +93,7 @@ function createSocialInfo(profiles) {
  */
 function createSocialAndLicenseInfo (tab, params) {
   var footer, footerContent,
-    completeLicenseInfo = params.license.url && params.license.name && params.show.title;
+    completeLicenseInfo = params.license && params.license.url && params.license.name && params.show.title;
   if (!completeLicenseInfo && !params.profiles) {
     return;
   }

--- a/src/js/modules/info.js
+++ b/src/js/modules/info.js
@@ -92,19 +92,18 @@ function createSocialInfo(profiles) {
  * @param  {object} params
  */
 function createSocialAndLicenseInfo (tab, params) {
-  var footer;
-  if ((!params.license.url || !params.license.name || !params.show.title) && !params.profiles) {
+  var footer, footerContent,
+    completeLicenseInfo = params.license.url && params.license.name && params.show.title;
+  if (!completeLicenseInfo && !params.profiles) {
     return;
   }
-  if (params.license.url && params.license.name && params.show.title) {
-    footer = tab.createFooter(
-      '<p class="license-area">Die Show "' + params.show.title + '" ist lizensiert unter<br>' +
+  footerContent = '';
+  if (completeLicenseInfo) {
+    footerContent = '<p class="license-area">Die Show "' + params.show.title + '" ist lizensiert unter<br>' +
         '<a href="' + params.license.url + '" target="_blank" title="Lizenz ansehen">' + params.license.name + '</a>' +
-      '</p>'
-    );
-  } else {
-    footer = tab.createFooter();
+      '</p>';
   }
+  footer = tab.createFooter(footerContent);
   footer.prepend(createSocialInfo(params.profiles));
 }
 

--- a/src/js/tab.js
+++ b/src/js/tab.js
@@ -99,7 +99,7 @@ Tab.prototype.createFooter = function(content) {
   if(!content) {
     content = '';
   }
-  footer = content ? $('<footer>' + content + '</footer>') : $('<footer></footer>');
+  footer = $('<footer>' + content + '</footer>');
   this.box.append(footer);
   return footer;
 };

--- a/src/js/tab.js
+++ b/src/js/tab.js
@@ -95,7 +95,7 @@ Tab.prototype.createAside = function(content) {
  * @param content
  */
 Tab.prototype.createFooter = function(content) {
-  var footer = $('<footer>' + content + '</footer>');
+  var footer = content ? $('<footer>' + content + '</footer>') : $('<footer></footer>');
   this.box.append(footer);
   return footer;
 };

--- a/src/js/tab.js
+++ b/src/js/tab.js
@@ -95,7 +95,11 @@ Tab.prototype.createAside = function(content) {
  * @param content
  */
 Tab.prototype.createFooter = function(content) {
-  var footer = content ? $('<footer>' + content + '</footer>') : $('<footer></footer>');
+  var footer;
+  if(!content) {
+    content = '';
+  }
+  footer = content ? $('<footer>' + content + '</footer>') : $('<footer></footer>');
   this.box.append(footer);
   return footer;
 };

--- a/src/sass/_license-area.scss
+++ b/src/sass/_license-area.scss
@@ -1,0 +1,9 @@
+//
+// Footer within tabs
+// --------------------------------------------------
+
+.tab footer .license-area {
+  border-top: 16px solid $white;
+  margin: 0;
+  padding: $padding-large-vertical $padding-base-horizontal;
+}

--- a/src/sass/_license-area.scss
+++ b/src/sass/_license-area.scss
@@ -2,7 +2,7 @@
 // Footer within tabs
 // --------------------------------------------------
 
-.tab footer .license-area {
+.tab .license-area {
   border-top: 16px solid $white;
   margin: 0;
   padding: $padding-large-vertical $padding-base-horizontal;

--- a/src/sass/_main.scss
+++ b/src/sass/_main.scss
@@ -54,6 +54,7 @@
 @import "modules/share";
 @import "social-profiles";
 @import "footer";
+@import "license-area";
 
 // Utility classes
 @import "utilities";

--- a/src/sass/_social-profiles.scss
+++ b/src/sass/_social-profiles.scss
@@ -3,7 +3,6 @@
 // --------------------------------------------------
 
 .social-links {
-  border-bottom: 16px solid $white;
   padding: $padding-large-vertical $padding-base-horizontal 15px;
   @media screen and (min-width: $screen-desktop) {
     padding: $padding-large-vertical $padding-base-horizontal;


### PR DESCRIPTION
Hi all,
I worked on https://github.com/podlove/podlove-web-player/issues/270.

The behavior now is:
Show license area in footer, only if param.license.url, param.license.name and param.show.title are defined. Independently from the visibility of the license area: show social links in footer, if param.profiles is defined.

About the SCSS changes:
I had to modify some CSS to hide the white border below the profiles area, if the license area is not visible (see attached image). 
Because the license area seems to me like a separate component, I didn't add the new selector ('license-area') to an existing SCSS file, but added a new file (_license-area.scss). @plutonik-a Please tell me, if this wasn't okay and I should add it somewhere else. ;)

![license-area](https://cloud.githubusercontent.com/assets/3409561/12703045/05136972-c839-11e5-9d28-8747735848f4.jpg)
