### PR TITLE
Show Scrubber completely

### DIFF
--- a/src/sass/_progressbar.scss
+++ b/src/sass/_progressbar.scss
@@ -175,7 +175,7 @@ progress[aria-valuenow]:before  {
 // -------------------------
 
 .progress {
-  margin: 0 ($progress-bar-height/2);
+  margin: 0 $margin-small-horizontal;
   position: relative;
   .current {
     width: 100%;

--- a/src/sass/_progressbar.scss
+++ b/src/sass/_progressbar.scss
@@ -215,6 +215,7 @@ progress[aria-valuenow]:before  {
 }
 
 .handle {
+  cursor: pointer;
   display: block;
   position: absolute;
   top: 0;

--- a/src/sass/_progressbar.scss
+++ b/src/sass/_progressbar.scss
@@ -175,7 +175,7 @@ progress[aria-valuenow]:before  {
 // -------------------------
 
 .progress {
-  margin: 0 auto;
+  margin: 0 ($progress-bar-height/2);
   position: relative;
   .current {
     width: 100%;


### PR DESCRIPTION
@plutonik-a @line-o Although the ticket says that the scrubber shall be removed, when an interaction with the progress bar or the play button happens, I wanted you to see an alternative suggestion first. The reason for that is primary the user experience: If we do not have to hide the scrubber sometimes it's more consistent behavior and we don't confuse someone, who's searching for the scrubber.
So I added some margins to the left and right of the progress bar. I think this has two positive side effects:
1. We can resolve the problem without adding additional scripts.
2. The margins effect the progress and buffer bars, too, which now have some pixels space to the left and right. Personally I think this has a positive effect for recognizing the progress and buffer as the actual bars on a background – unlike before, when the space below and above the buffer bar, looked for me, if they could be bars, too. Do you know what I mean? 

I attached a screenshot, how it looked before and how it would look now. Tell me, what you think, and/or if you prefer another/the other solution :)

Ah, and before I forget: I added a pointer cursor to the progress handle / scrubber. Is this okay or was there a reason for not having a pointer cursor?

![scrubber](https://cloud.githubusercontent.com/assets/3409561/12888887/786a307e-ce7c-11e5-95e8-1f947477199c.jpg)

