### PR TITLE
Use SPDX license identifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,12 +9,7 @@
   "bugs": {
     "url": "https://github.com/podlove/podlove-web-player/issues"
   },
-  "licenses": [
-    {
-      "type": "BSD 2-Clause License",
-      "url": "http://opensource.org/licenses/BSD-2-Clause"
-    }
-  ],
+  "license": "BSD-2-Clause",
   "keywords": [
     "podcasting",
     "podlove",


### PR DESCRIPTION
Using a SPDX license identifier makes it easier to detect the license and will also display the license on [npmjs.com](https://www.npmjs.com/package/@podlove/podlove-web-player). See also [npm’s documentation](https://docs.npmjs.com/files/package.json#license).