### PR TITLE
Change A11Y progressbar label from milliseconds to seconds

### DIFF
--- a/src/lang/de.json
+++ b/src/lang/de.json
@@ -111,7 +111,7 @@
     "PLAYER_CHAPTER_CURRENT": "Zum Anfang des aktiven Kapitels springen: {index} - {title}",
     "PLAYER_STEPPER_BACK": "{seconds} Sekunden zurückspringen",
     "PLAYER_STEPPER_FORWARD": "{seconds} Sekunden vorspringen",
-    "PROGRESSBAR_INPUT": "Spielzeit in Millisekunden ändern",
+    "PROGRESSBAR_INPUT": "Spielzeit in Sekunden ändern",
     "TIMER_CURRENT": "Aktuelle Spielzeit: {hours} Stunden {minutes} Minuten {seconds} Sekunden",
     "TIMER_LEFT": "Verbleibende Spielzeit: {hours} Stunden {minutes} Minuten {seconds} Sekunden",
     "TIMER_CHAPTER": "Aktuelles Kapitel: {index} - {title}",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -106,7 +106,7 @@
     "PLAYER_CHAPTER_CURRENT": "Go to the Beginning of the Current Chapter: {index} - {title}",
     "PLAYER_STEPPER_BACK": "Rewind {seconds} Seconds",
     "PLAYER_STEPPER_FORWARD": "Fast Forward {seconds} Seconds",
-    "PROGRESSBAR_INPUT": "Change Playtime in Milliseconds",
+    "PROGRESSBAR_INPUT": "Change Playtime in Seconds",
     "TIMER_CURRENT": "Current Playtime: {hours} hours {minutes} minutes {seconds} seconds",
     "TIMER_LEFT": "Playtime Left: {hours} hours {minutes} minutes {seconds} seconds",
     "TIMER_CHAPTER": "Current Chapter: {index} - {title}",


### PR DESCRIPTION
As far as I can see one is only able to change the playtime in seconds instead of milliseconds through the progress bar.

Note: `eo.json` and `ru.json` need to be updated, too.