### PR TITLE
doc: fix mp3 mimeType

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -103,7 +103,7 @@ _Not providing chapters will disable all chapter related functions._
     title: 'Audio MP4'
   }, {
     url: 'http://freakshow.fm/podlove/file/4467/s/download/c/select-show/fs171-invasion.mp3',
-    mimeType: 'audio/mp3',
+    mimeType: 'audio/mpeg',
     size: 14665000,
     title: 'Audio MP3'
   }, {


### PR DESCRIPTION
`audio/mp3` is not a valid mime type