### PR TITLE
WIP: feat: use webshare if available

### DIFF
--- a/src/components/tabs/share/ShareChannels.vue
+++ b/src/components/tabs/share/ShareChannels.vue
@@ -1,5 +1,6 @@
 <template>
   <ul class="channel-list" id="tab-share--channels">
+    <li id="tab-share--channels--native" v-if="nativeShareIsSupported()" @click="shareNative">NATIVE SHARE</li>
     <li id="tab-share--channels--twitter"><channel-twitter-component :text="shareText"></channel-twitter-component></li>
     <li id="tab-share--channels--facebook"><channel-facebook-component :link="shareLink"></channel-facebook-component></li>
     <li id="tab-share--channels--pinterest"><channel-pinterest-component :text="shareText" :link="shareLink" :poster="sharePoster"></channel-pinterest-component></li>
@@ -133,6 +134,19 @@
       ChannelPinterestComponent,
       ChannelRedditComponent,
       ChannelLinkedinComponent
+    },
+    methods: {
+      shareNative () {
+        const data = {
+          title: this.shareSubject,
+          text: this.shareText,
+          url: this.episode.link,
+        }
+        window.navigator.share(data)
+      },
+      nativeShareIsSupported() {
+        return 'share' in navigator
+      }
     }
   }
 </script>


### PR DESCRIPTION
This will provide the possibility to share the episode via the [webshare api](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/share) and therefore with the native share dialog on iOS and Android. This gives the user a much better ux.

I did not create an appropriate icon, because I think this is up to you to decide. That's the reason why it is prefixed with `WIP`.

If you have any questions towards this great feature, I will be happy to reply to you.

PS: Actually this only works on https, but to facilitate local development, the API also works when your site is running over localhost.